### PR TITLE
updates githubLabelLink to use the config.repo

### DIFF
--- a/frontend/src/components/Column/Column.js
+++ b/frontend/src/components/Column/Column.js
@@ -196,7 +196,7 @@ export default class Column extends Component {
       if (item.labels && item.labels.length) {
         // console.log(item.labels)
         item.labels.forEach((l, n) => {
-          const githubLabelLink = `https://github.com/serverless/serverless/labels/${l.name}`
+          const githubLabelLink = `https://github.com/${config.repo}/labels/${l.name}`
           testTags.push(
             <a key={n} className={styles.labelLink} href={githubLabelLink} target='_blank'>
               <span className={styles.tag} style={{background: `#${l.color}`}}>


### PR DESCRIPTION
the githubLabelLink was hardcoded to link to serverless/serverless repo, this PR makes sure it uses config.repo instead, like the githubIssueURL does.